### PR TITLE
Migrate everything to literate Agda

### DIFF
--- a/FormalTopology/BaireSpace.lagda.md
+++ b/FormalTopology/BaireSpace.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Baire Space
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 open import Cubical.Core.Everything
@@ -49,4 +54,4 @@ mp : IsDC P → IsDC Q → σ ◀ P → σ ◀ Q → σ ◀ (λ - → P - × Q -
 mp P-dc Q-dc (dir    σεP)        σ◀Q = lemma P-dc σεP σ◀Q
 mp P-dc Q-dc (branch f)          σ◀Q = branch (λ n → mp P-dc Q-dc (f n) (ζ n Q-dc σ◀Q))
 mp P-dc Q-dc (squash σ◀P σ◀P′ i) σ◀Q = squash (mp P-dc Q-dc σ◀P σ◀Q) (mp P-dc Q-dc σ◀P′ σ◀Q) i
-
+```

--- a/FormalTopology/FormalTopology.lagda.md
+++ b/FormalTopology/FormalTopology.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Formal Topology
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 module FormalTopology where
@@ -67,3 +72,4 @@ mono (_ , _ , φ , _) = φ
 
 sim : (ℱ : FormalTopology ℓ₀ ℓ₁) → hasSimulation (pos ℱ) (IS ℱ)
 sim (_ , _ , _ , φ) = φ
+```

--- a/FormalTopology/Frame.lagda.md
+++ b/FormalTopology/Frame.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Frame
+---
+
+```agda
 {-# OPTIONS --without-K --cubical --safe #-}
 
 module Frame where

--- a/FormalTopology/Nucleus.lagda.md
+++ b/FormalTopology/Nucleus.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Nucleus
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 module Nucleus where
@@ -193,3 +198,4 @@ nuclear-image L j N@(n₀ , n₁ , n₂) = isoToPath (iso f g sec-f-g ret-f-g)
           j (x ⊓[ L ] (⋁L U₀))               ≡⟨ cong j (dist L x U₀)                 ⟩
           j (⋁L ⁅ x ⊓[ L ] yᵢ ∣ yᵢ ε U₀ ⁆)   ≡⟨ refl                                 ⟩
           π₀ (⋁⟨ i ⟩ (𝓍 ∧ (U $ i)))          ∎
+```

--- a/FormalTopology/ProductTopology.lagda.md
+++ b/FormalTopology/ProductTopology.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Product Topology
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 module ProductTopology where

--- a/FormalTopology/Sierpinski.lagda.md
+++ b/FormalTopology/Sierpinski.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Sierpinski
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 module Sierpinski where
@@ -50,3 +55,4 @@ open import FormalTopology
     𝕊-has-sim false false x tt = tt , λ { tt → tt , tt }
     𝕊-has-sim false true  x tt = tt , λ { tt → tt , tt }
     𝕊-has-sim true  true  x tt = tt , λ { tt → tt , tt }
+```

--- a/FormalTopology/SnocList.lagda.md
+++ b/FormalTopology/SnocList.lagda.md
@@ -1,3 +1,8 @@
+---
+title: Snoc List
+---
+
+```agda
 {-# OPTIONS --cubical --safe #-}
 
 open import Basis

--- a/FormalTopology/generate_html.sh
+++ b/FormalTopology/generate_html.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 
-agda --safe Main.lagda.md
+echo "Running Agda..."
 
-for f in `ls *.lagda.md`; do
-    agda --html --html-highlight=auto $f
-done
-
-for f in `ls *.agda`; do
-    agda --css Agda.css --html --html-highlight=code $f
-done
+agda --safe --html --html-highlight=auto Main.lagda.md
 
 cp -f ../resources/Agda.css html/Agda.css
 
 cd html
 
 for f in `ls *.md`; do
+    echo "Compiling Markdown: $f..."
     pandoc $f --css Agda.css -o "$(basename --suffix='.md' $f).html"
 done


### PR DESCRIPTION
Use `.lagda.md` files for the sake of consistency. This also simplifies the HTML generation stuff.